### PR TITLE
Add TweetClaw X automation tool

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ Manual content creation is a context-switching nightmare for developers. This re
 
 * **[Taplio](https://taplio.com/)** - The OS for LinkedIn. Includes a CRM to DM people who interact with your posts (high conversion).
 * **[Hypefury](https://hypefury.com/)** - Best for Twitter sales. "Auto-plugs" your product when a tweet goes viral.
+* **[TweetClaw](https://github.com/Xquik-dev/tweetclaw)** - OpenClaw plugin and Xquik API client for agent workflows that search tweets, post tweets and replies, monitor keywords, send DMs, handle webhooks, and run giveaway draws on X/Twitter.
 * **[Buffer](https://buffer.com/)** - The best free tier for cross-posting to Bluesky, Mastodon, and LinkedIn simultaneously.
 * **[Shield](https://www.shieldapp.ai/)** - Pure analytics. If you are serious about data-driven growth on LinkedIn, this is the dashboard you need.
 


### PR DESCRIPTION
## Summary
- Add TweetClaw to the Scheduling & CRM section as a shipping X/Twitter automation tool for developer-led personal branding workflows.
- Highlight concrete jobs users search for: search tweets, post tweets and replies, monitor keywords, direct messages, webhooks, and giveaway draws.
- Keep the existing README style and avoid adding unrelated badge changes.

## Validation
- Read README contribution instructions, repository metadata, issue state, PR state, and duplicate search results.
- Confirmed no existing TweetClaw, Xquik, x-twitter-scraper, or @xquik/tweetclaw mention.
- Checked that no CONTRIBUTING, license file, code of conduct, security policy, or PR/issue templates exist beyond the README instructions and CC0 badge.
- Ran git diff --check.
